### PR TITLE
ENG-633: Increasing DBus Robustness

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>rviz</name>
-  <version>1001.0.3</version>
+  <version>1001.0.4</version>
   <description>
      3D visualization tool for ROS.
   </description>

--- a/scripts/rvnbag_play.py
+++ b/scripts/rvnbag_play.py
@@ -403,7 +403,6 @@ class PublicationControl(object):
         this method. This ensures that an initial re-seek back to 0 does not befoul the 
         tf tree.
         """
-        print "*** Have read signal"
         if self._initial_seek_lock: return 0.0
 
         old_clock = rospy.Time(0)

--- a/scripts/rvnbag_play.py
+++ b/scripts/rvnbag_play.py
@@ -435,21 +435,8 @@ class PublicationControl(object):
 
 # ----------------------------------------------------------------------------------------------------------------------
 
-_dbus_lockfile = "./.rvn.dbus.ready"
-
-def _rm_dbus_lockfile():
-    if os.path.isfile(_dbus_lockfile):
-        os.remove(_dbus_lockfile)
-
-def _create_dbus_lockfile():
-    with open(_dbus_lockfile, 'w'):
-        os.utime( _dbus_lockfile, None)
-
-
-
 def main():
     rospy.loginfo("Starting Raven[ops] ROS Bag Player") 
-    _rm_dbus_lockfile()
 
     verbose = False
     bagfile = ""
@@ -491,10 +478,6 @@ def main():
         rospy.logerr("Unable to set up session dbus: {}".format(e))
         return ExitStatus.PUB_FAIL
     
-    # RVN::TODO: This is a rather hacky solution, but solves the waiting for dbus problem before we spin up RVIZ
-    #            Once this file exists, the dbus is OK and the bag is loaded
-    _create_dbus_lockfile()
-
     rospy.loginfo("published to the '{}' dbus ".format(service_name))
     rospy.loginfo("running the main loop...")
 

--- a/scripts/rvnbag_play.py
+++ b/scripts/rvnbag_play.py
@@ -3,7 +3,6 @@
 Raven[ player ]
 
 Iain Brookshaw
-2018.10.30
 Copyright (c) 2018, Raven Ops Inc., All Rights Reserved
 
 Raven Rosbag player, using D-Bus to communicate to the RvnRviz renderer

--- a/src/rviz/dump_images_config.h
+++ b/src/rviz/dump_images_config.h
@@ -12,6 +12,7 @@ struct DumpImagesConfig {
   bool enabled;
   std::string folder;
   float fps;
+  float timeout;
 
   uint delayFrames;
   double frameWidth;

--- a/src/rviz/visualization_manager.cpp
+++ b/src/rviz/visualization_manager.cpp
@@ -426,12 +426,14 @@ void VisualizationManager::onUpdate()
 
     if(dump_images_config_->bagDuration == 0 && frame_count_ > dump_images_config_->delayFrames)
     {
-      QDBusReply<double> reply = dbus_->call("seek", 0.0);
+      ROS_INFO("Re-Seeking to start of the bag, this may take a few seconds as bag loads...");
+      QDBusReply<double> reply = dbus_->call("seek", 0.0, (double)30.0); // RVN::FIX: hardcoded timeout here to 30 seconds
       if (!reply.isValid())
       { 
         ROS_ERROR("lastTimeSeconds error: '%s'", reply.error().message().toStdString().c_str());
         exit(EXIT_FAILURE);
       }
+      ROS_INFO("...Re-Seek done.");
       dump_images_config_->bagDuration = reply.value();
       ROS_INFO("Bag duration %f seconds.", dump_images_config_->bagDuration);
       nextFrame();
@@ -504,7 +506,7 @@ void VisualizationManager::onUpdate()
 
 void VisualizationManager::nextFrame()
 {
-  QDBusReply<double> reply = dbus_->call("read", dump_images_config_->frameWidth);
+  QDBusReply<double> reply = dbus_->call("read", dump_images_config_->frameWidth, (double)30.0); // RVN::FIX: Hardcoded timeout here to 30.0 seconds
   if (!reply.isValid())
   {
     ROS_ERROR(

--- a/src/rviz/visualization_manager.cpp
+++ b/src/rviz/visualization_manager.cpp
@@ -542,7 +542,7 @@ void VisualizationManager::onUpdate()
 
 void VisualizationManager::nextFrame()
 {
-  QDBusReply<double> reply = dbus_->call("read", dump_images_config_->frameWidth, 30.0);
+  QDBusReply<double> reply = dbus_->call("read", dump_images_config_->frameWidth, dump_images_config_->timeout);
   if (!reply.isValid())
   {
     ROS_ERROR(

--- a/src/rviz/visualization_manager.cpp
+++ b/src/rviz/visualization_manager.cpp
@@ -542,7 +542,7 @@ void VisualizationManager::onUpdate()
 
 void VisualizationManager::nextFrame()
 {
-  QDBusReply<double> reply = dbus_->call("read", dump_images_config_->frameWidth, (double)30.0); // RVN::FIX: Hardcoded timeout here to 30.0 seconds
+  QDBusReply<double> reply = dbus_->call("read", dump_images_config_->frameWidth, 30.0);
   if (!reply.isValid())
   {
     ROS_ERROR(

--- a/src/rviz/visualization_manager.cpp
+++ b/src/rviz/visualization_manager.cpp
@@ -230,7 +230,7 @@ VisualizationManager::VisualizationManager(RenderPanel* render_panel,DumpImagesC
     QString dbusPath = QString(rvn_service_name).replace(".","/").prepend("/");
 
     int sleep_sec = 1;
-    int max_tries = sleep_sec * dump_images_config_->timeout; //RVN::TODO: Timeout is arbitrary and hard-coded for now.
+    int max_tries = sleep_sec * dump_images_config_->timeout;
     int tries = 0;
     while( true ){
 

--- a/src/rviz/visualization_manager.cpp
+++ b/src/rviz/visualization_manager.cpp
@@ -230,7 +230,7 @@ VisualizationManager::VisualizationManager(RenderPanel* render_panel,DumpImagesC
     QString dbusPath = QString(rvn_service_name).replace(".","/").prepend("/");
 
     int sleep_sec = 1;
-    int max_tries = sleep_sec * 30; //RVN::TODO: Timeout is arbitrary and hard-coded for now.
+    int max_tries = sleep_sec * dump_images_config_->timeout; //RVN::TODO: Timeout is arbitrary and hard-coded for now.
     int tries = 0;
     while( true ){
 
@@ -463,7 +463,7 @@ void VisualizationManager::onUpdate()
     if(dump_images_config_->bagDuration == 0 && frame_count_ > dump_images_config_->delayFrames)
     {
       ROS_INFO("Re-Seeking to start of the bag, this may take a few seconds as bag loads...");
-      QDBusReply<double> reply = dbus_->call("seek", 0.0, (double)30.0); // RVN::FIX: hardcoded timeout here to 30 seconds
+      QDBusReply<double> reply = dbus_->call("seek", 0.0, (double)dump_images_config_->timeout);
       if (!reply.isValid())
       { 
         ROS_ERROR("lastTimeSeconds error: '%s'", reply.error().message().toStdString().c_str());

--- a/src/rviz/visualization_manager.h
+++ b/src/rviz/visualization_manager.h
@@ -346,8 +346,6 @@ protected Q_SLOTS:
 
   void onToolChanged( Tool* );
 
-  void onFoundDbusService();
-
 protected:
   void updateTime();
   void updateFrames();
@@ -405,9 +403,6 @@ protected:
   QWindow* window_;
   DumpImagesConfig* dump_images_config_;
   QDBusInterface* dbus_;
-  bool found_dbus_service;
-  QDBusServiceWatcher* dbus_watcher_;
-
 
 private Q_SLOTS:
   void updateFixedFrame();

--- a/src/rviz/visualizer_app.cpp
+++ b/src/rviz/visualizer_app.cpp
@@ -150,7 +150,8 @@ bool VisualizerApp::init(int argc, char **argv)
       ("dump-images", "On every screen render dump a jpg of contents.")
       ("dump-folder",po::value<std::string>()->default_value("dump"), "Sets the folder for dumped images.")
       ("dump-fps",po::value<float>()->default_value(30.0), "Frames per second for dumped images.  Can be floating point.")
-      ("dump-delay",po::value<float>()->default_value(1.5), "Delay X seconds until seeking bag file on DBus.");
+      ("dump-delay",po::value<float>()->default_value(1.5), "Delay X seconds until seeking bag file on DBus.")
+      ("dump-timeout",po::value<float>()->default_value(30), "Retry initial connection to DBus for X seconds failing.");
 
     po::variables_map vm;
     std::string display_config, fixed_frame, splash_path, help_path, dump_folder;
@@ -247,6 +248,7 @@ bool VisualizerApp::init(int argc, char **argv)
         dump_images_config->enabled = true;
         dump_images_config->folder = vm["dump-folder"].as<std::string>();
         dump_images_config->fps = vm["dump-fps"].as<float>();
+        dump_images_config->timeout = vm["dump-timeout"].as<float>();
         dump_images_config->frameWidth = 1 / dump_images_config->fps;
         dump_images_config->delayFrames = uint(ceil(vm["dump-delay"].as<float>() * dump_images_config->fps));
         dump_images_config->bagDuration = 0;


### PR DESCRIPTION
# Summary
The Dbus connection between the `rvnbag_player` and `rviz` was vulnerable to timing errors
* program start order used to be critical
* large bags could throw off the hard-coded sleep intervals
These issues have been addressed by two features:
1. `rvnbag_play` now loads the bag  as a separate  thread, with dbus callbacks hanging until the bag is available
2. `rviz` will halt until the correct service is registered with the system dbus.

Both of these have hard-coded timeouts of 30sec (set in `rviz`) Rviz should `EXIT_FAILURE` if these expire, but that behavior is essentially undefined (and untested)

This means that bags can be of any size and the two programs can be started in any relative order (provided timeouts do not expire). 

# Testing steps
1. recompile `rviz`
2. source the workspace
3. test.bag =  with any reasonably big (> 5GB) bag
4. `rviz -d test.rviz --dump-images & sleep 5 && rvnbag_play.py -b test.bag`
5. `rvnbag_play.py -b test.bag & sleep 5 && rviz -d test.rviz --dump-images`
Note that both of these should work