### PR TITLE
Encode mp4 and thumnail as frames are captured from ogre

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(rviz)
+add_subdirectory(rviz_video_encoder)
 add_subdirectory(image_view)
 if (CATKIN_ENABLE_TESTING)
   add_subdirectory(test)

--- a/src/rviz/CMakeLists.txt
+++ b/src/rviz/CMakeLists.txt
@@ -143,6 +143,7 @@ target_link_libraries(${PROJECT_NAME}
   ${X11_X11_LIB}
   assimp
   yaml-cpp
+  rviz_video_encoder
 )
 
 

--- a/src/rviz/dump_images_config.h
+++ b/src/rviz/dump_images_config.h
@@ -10,9 +10,13 @@ namespace rviz
 
 struct DumpImagesConfig {
   bool enabled;
-  std::string folder;
-  float fps;
-  float timeout;
+  std::string captured_path;
+  std::string keyed_path;
+  std::string thumb_path;
+  int thumbWidth;
+  int fpsNum;
+  int fpsDen;
+  double timeout;
 
   uint delayFrames;
   double frameWidth;

--- a/src/rviz/visualization_manager.cpp
+++ b/src/rviz/visualization_manager.cpp
@@ -371,8 +371,7 @@ ros::CallbackQueueInterface* VisualizationManager::getUpdateQueue()
 
 void VisualizationManager::startUpdate()
 {
-    //  float interval = 1000.0 / float(fps_property_->getInt());
-  float interval = 0.0;
+  float interval = 1000.0 / float(fps_property_->getInt());
   update_timer_->start( interval );
 }
 

--- a/src/rviz/visualization_manager.cpp
+++ b/src/rviz/visualization_manager.cpp
@@ -519,6 +519,12 @@ void VisualizationManager::onUpdate()
     if (shouldDump  && dump_images_config_->bagDuration > 0)
     {
       QPixmap screenshot_ = screen_->grabWindow(window_->winId());
+      if (screenshot_.width() % 2 || screenshot_.height() % 2) {
+          // ensure screenshot width are height are divisible by two
+          int w = screenshot_.width();
+          int h = screenshot_.height();
+          screenshot_ = screenshot_.copy(0, 0, w - (w%2), h - (h%2));
+      }
       QImage img = screenshot_.toImage();
 
       if ( private_->venc_ == NULL){
@@ -594,7 +600,7 @@ void VisualizationManager::onUpdate()
           exit(EXIT_FAILURE);
       }
 
-      // screenshot
+      // thumbnail
       double midway = dump_images_config_->bagDuration / 2.0;
       double curTime = dump_images_config_->lastEventTime - private_->bag_start;
       if ( curTime >= midway && !private_->thumbnail_taken )
@@ -606,7 +612,7 @@ void VisualizationManager::onUpdate()
           QImageWriter writer(filename);
           if (!writer.write(img.scaledToWidth(dump_images_config_->thumbWidth)))
           {
-              ROS_ERROR("failed writing screenshot file %s: err %d",dump_images_config_->thumb_path.c_str(),writer.error());
+              ROS_ERROR("failed writing thumbnail file %s: err %d",dump_images_config_->thumb_path.c_str(),writer.error());
               exit(EXIT_FAILURE);
           }
           ROS_INFO("Wrote thumbnail at %f of %f (midway = %f)\n", curTime, dump_images_config_->bagDuration, midway);

--- a/src/rviz/visualization_manager.cpp
+++ b/src/rviz/visualization_manager.cpp
@@ -157,7 +157,7 @@ VisualizationManager::VisualizationManager(RenderPanel* render_panel,DumpImagesC
 , frame_count_(0)
 , dumped_frame_count_(0)
 , window_manager_(wm)
-, private_( new VisualizationManagerPrivate )
+, private_( new VisualizationManagerPrivate {})
 {
   // visibility_bit_allocator_ is listed after default_visibility_bit_ (and thus initialized later be default):
   default_visibility_bit_ = visibility_bit_allocator_.allocBit();
@@ -519,11 +519,11 @@ void VisualizationManager::onUpdate()
     if (shouldDump  && dump_images_config_->bagDuration > 0)
     {
       QPixmap screenshot_ = screen_->grabWindow(window_->winId());
-      if (screenshot_.width() % 2 || screenshot_.height() % 2) {
-          // ensure screenshot width are height are divisible by two
+      if (screenshot_.width() % 4 || screenshot_.height() % 4) {
+          // ensure screenshot width are height are divisible by four
           int w = screenshot_.width();
           int h = screenshot_.height();
-          screenshot_ = screenshot_.copy(0, 0, w - (w%2), h - (h%2));
+          screenshot_ = screenshot_.copy(0, 0, w - (w % 4), h - (h % 4));
       }
       QImage img = screenshot_.toImage();
 

--- a/src/rviz/visualization_manager.h
+++ b/src/rviz/visualization_manager.h
@@ -403,7 +403,6 @@ protected:
   QWindow* window_;
   DumpImagesConfig* dump_images_config_;
   QDBusInterface* dbus_;
-
 private Q_SLOTS:
   void updateFixedFrame();
   void updateBackgroundColor();

--- a/src/rviz_video_encoder/CMakeLists.txt
+++ b/src/rviz_video_encoder/CMakeLists.txt
@@ -1,0 +1,25 @@
+add_library(rviz_video_encoder
+  video_encoder.c
+)
+
+target_link_libraries(rviz_video_encoder
+  "swscale"
+  "avcodec"
+  "avutil"
+  "avformat"
+  "xxhash"
+)
+
+set_target_properties(rviz_video_encoder
+                      PROPERTIES OUTPUT_NAME rviz_video_encoder
+                      PREFIX ""
+                      )
+
+
+install(TARGETS rviz_video_encoder
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+)
+
+install(DIRECTORY ./
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+  FILES_MATCHING PATTERN "*.h")

--- a/src/rviz_video_encoder/video_encoder.c
+++ b/src/rviz_video_encoder/video_encoder.c
@@ -1,0 +1,302 @@
+#include <stdint.h>
+
+#include <libswscale/swscale.h>
+#include <libavcodec/avcodec.h>
+#include <libavutil/common.h>
+#include <libavformat/avformat.h>
+#include <libavutil/timestamp.h>
+#include <libavutil/imgutils.h>
+
+#include "xxhash.h"
+#include "video_encoder.h"
+
+struct _video_encoder {
+    VideoEncodeParams params;
+    int out_width,out_height;
+
+    // video encoding
+    AVCodecContext *cc;
+    // output muxing
+    AVFormatContext *oc;
+
+    struct SwsContext *sws;
+
+    AVFrame *frame_raw,*frame_scaled;
+
+    AVPacket pbuf;
+
+    AVStream *st;
+
+    uint32_t num_frames,skipped_frames;
+
+    // for keyed capture
+    long long unsigned last_frame_hash;
+};
+
+VideoEncoder* video_encoder_init(VideoEncodeParams params){
+    // RVN:TODO: hardcoded for now
+    params.inFmt = AV_PIX_FMT_RGB32;
+
+    VideoEncoder *enc = (VideoEncoder*) malloc(sizeof(VideoEncoder));
+    if ( enc == NULL )
+    {
+        fprintf(stderr,"could not allocate VideoEncoder");
+        return NULL;
+    }
+    memset(enc,0,sizeof(VideoEncoder));
+
+    enc->params = params;
+
+    printf("[video encoder] capping width at %dpx\n",enc->params.maxWidth);
+    float aspectRatio = (float) enc->params.width / (float) enc->params.height;
+    enc->out_width = enc->params.width > enc->params.maxWidth ? enc->params.maxWidth : enc->params.width;
+    enc->out_height = (int) ((float) enc->out_width / aspectRatio);
+
+    // ensure output dimensions are divisible by 2
+    if (enc->out_width % 2) {
+        enc->out_width--;
+    }
+    if (enc->out_height % 2) {
+        enc->out_height--;
+    }
+
+    printf("[video encoder init] %d x %d --> %d x %d @ %f FPS\n",
+	   enc->params.width,enc->params.height,
+	   enc->out_width,enc->out_height,
+	   (double) enc->params.fpsNum / (double) enc->params.fpsDen);
+
+    // init scaled input buffer frame
+    enc->frame_scaled = av_frame_alloc();
+    enc->frame_scaled->width = enc->out_width;
+    enc->frame_scaled->height = enc->out_height;
+    enc->frame_scaled->format = AV_PIX_FMT_YUV420P;
+
+    enc->frame_raw = av_frame_alloc();
+    enc->frame_raw->width = enc->params.width;
+    enc->frame_raw->height = enc->params.height;
+    enc->frame_raw->format = enc->params.inFmt;
+
+    int ret;
+    ret = av_frame_get_buffer(enc->frame_scaled, 32);
+    if (ret < 0) {
+        fprintf(stderr, "Could not allocate frame data: %s\n",av_err2str(ret));
+        return NULL;
+    }
+    ret = av_frame_get_buffer(enc->frame_raw, 32);
+    if (ret < 0) {
+        fprintf(stderr, "Could not allocate frame data: %s\n",av_err2str(ret));
+        return NULL;
+    }
+
+    // set up sws context
+    enc->sws = sws_getContext(enc->params.width, enc->params.height, enc->params.inFmt,
+			      enc->out_width, enc->out_height, AV_PIX_FMT_YUV420P,
+			      SWS_FAST_BILINEAR, NULL, NULL, NULL);
+
+    enum AVCodecID codec_id = AV_CODEC_ID_H264;
+    // codec
+    AVCodec *codec = avcodec_find_encoder(codec_id);
+    if (!codec){
+        fprintf(stderr,"Could not find h264 codec: %d\n",codec_id);
+        return NULL;
+    }
+
+    // output format context
+    ret = avformat_alloc_output_context2(&enc->oc,NULL,NULL,enc->params.output_path);
+    if (!enc->oc){
+        fprintf(stderr,"could not alloc output context: %s\n", av_err2str(ret));
+        return NULL;
+    }
+    ret = avio_open(&enc->oc->pb, enc->params.output_path, AVIO_FLAG_WRITE);
+    if (ret < 0) {
+        fprintf(stderr, "could not open output file '%s': %s\n", enc->params.output_path, av_err2str(ret));
+        return NULL;
+    }
+
+    enc->st = avformat_new_stream(enc->oc,NULL);
+    enc->st->id = enc->oc->nb_streams-1;
+
+    enc->cc = avcodec_alloc_context3(codec);
+    if(!enc->cc){
+        fprintf(stderr,"failed to allocate context for codec: %d\n",codec_id);
+        return NULL;
+    }
+
+    // set video encoder params
+    enc->cc->codec_id = codec_id;
+    enc->cc->width = enc->out_width;
+    enc->cc->height = enc->out_height;
+    enc->st->time_base = (AVRational){enc->params.fpsDen,enc->params.fpsNum};
+    enc->cc->time_base = enc->st->time_base;
+
+    enc->cc->pix_fmt = enc->frame_scaled->format;
+
+    enc->cc->profile = FF_PROFILE_H264_BASELINE;
+
+    if (enc->oc->oformat->flags & AVFMT_GLOBALHEADER)
+        enc->cc->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
+
+    // open the codec
+    AVDictionary *opt = NULL;
+    av_dict_copy(&opt, NULL, 0);
+
+    //crf
+    char crf_str[5];
+    sprintf(crf_str,"%.1f",enc->params.crf);
+    av_dict_set(&opt, "crf", crf_str, 0);
+
+    //preset
+    av_dict_set(&opt, "preset", enc->params.preset, 0);
+
+    /* open the codec */
+    ret = avcodec_open2(enc->cc, codec, &opt);
+    av_dict_free(&opt);
+    if (ret < 0) {
+        fprintf(stderr, "Could not open video codec: %s\n", av_err2str(ret));
+        return NULL;
+    }
+
+    // copy stream params to muxer
+    ret = avcodec_parameters_from_context(enc->st->codecpar, enc->cc);
+    if (ret < 0) {
+        fprintf(stderr, "Could not copy the stream parameters: %s\n",av_err2str(ret));
+        return NULL;
+    }
+
+    fprintf(stdout,"Writing header\n");
+    ret = avformat_write_header(enc->oc,NULL);
+    if (ret < 0){
+        fprintf(stderr," error writing output file header: %s\n",av_err2str(ret));
+        return NULL;
+    }
+
+    // init bookeeping
+    enc->num_frames = 0;
+
+    fprintf(stdout,"[video encoder] initialized!\n");
+    return enc;
+
+}
+
+static int write_frame(AVFormatContext *fmt_ctx, const AVRational *time_base, AVStream *st, AVPacket *pkt)
+{
+    av_packet_rescale_ts(pkt, *time_base, st->time_base);
+    pkt->stream_index = st->index;
+
+    return av_interleaved_write_frame(fmt_ctx, pkt);
+}
+
+static int video_encoder_send_frame(VideoEncoder *enc, AVFrame *frame){
+    int ret;
+    ret = avcodec_send_frame(enc->cc,frame);
+    if (ret < 0){
+        fprintf(stderr, "error encoding video frame: %s\n", av_err2str(ret));
+        return ret;
+    }
+    while (1)
+    {
+        av_init_packet(&enc->pbuf);
+        enc->pbuf.data = NULL;
+        enc->pbuf.size = 0;
+
+        ret = avcodec_receive_packet(enc->cc,&enc->pbuf);
+        if (ret < 0){
+            if (ret == AVERROR_EOF) {
+                fprintf(stdout,"[video encoder] EOF\n");
+                break;
+            }
+            if (ret == AVERROR(EAGAIN)){
+                break;
+            }
+
+            fprintf(stderr,"error receiving packet from encoder: %s\n",av_err2str(ret));
+            return ret;
+        }
+        ret = write_frame(enc->oc, &enc->cc->time_base, enc->st, &enc->pbuf);
+        if (ret < 0) {
+            fprintf(stderr, "error while writing video frame to transport stream: %s\n", av_err2str(ret));
+            return ret;
+        }
+        av_packet_unref(&enc->pbuf);
+    }
+    return 0;
+}
+
+int video_encoder_encode_frame(VideoEncoder *enc, const uint8_t *pixels){
+    int ret;
+    ret = av_frame_make_writable(enc->frame_raw);
+    if(ret < 0 ){
+        fprintf(stderr, "[video encoder] error allocating frame: %s\n",av_err2str(ret));
+        return ret;
+    }
+    ret = av_frame_make_writable(enc->frame_scaled);
+    if(ret < 0 ){
+        fprintf(stderr, "[video encoder] error allocating frame: %s\n",av_err2str(ret));
+        return ret;
+    }
+
+    int bytesFilled = av_image_fill_arrays(enc->frame_raw->data,
+                                           enc->frame_raw->linesize,
+                                           pixels,
+                                           enc->frame_raw->format,
+                                           enc->frame_raw->width,enc->frame_raw->height,32);
+    if(!bytesFilled){
+       fprintf(stderr,"Could not fill raw picture bytes\n");
+       return -1;
+    }
+
+    if (enc->params.keyed){
+        unsigned long long const frame_hash = XXH64((void*) pixels, bytesFilled, 0);
+        if (enc->last_frame_hash == frame_hash){
+            // no change since last frame. skip
+            enc->skipped_frames++;
+            return 0;
+        }
+
+        enc->last_frame_hash = frame_hash;
+    }
+
+    enc->frame_scaled->pts = enc->num_frames++;
+    sws_scale(enc->sws,
+              (const uint8_t * const *) enc->frame_raw->data,
+	      enc->frame_raw->linesize,
+              0,
+              enc->params.height,
+              enc->frame_scaled->data,
+              enc->frame_scaled->linesize
+              );
+
+
+
+    return video_encoder_send_frame(enc,enc->frame_scaled);
+}
+
+void video_encoder_destroy(VideoEncoder *enc)
+{
+    if(enc){
+        fprintf(stdout,"Encode finished!: %d frames encoded, %d frames skipped\n",enc->num_frames, enc->skipped_frames);
+	if(enc->sws){
+            sws_freeContext(enc->sws);
+        }
+        if (enc->cc){
+            // flush codec
+            video_encoder_send_frame(enc,NULL);
+            avcodec_free_context(&enc->cc);
+        }
+        if (enc->frame_scaled){
+            av_frame_free(&enc->frame_scaled);
+        }
+        if (enc->frame_raw){
+            av_frame_free(&enc->frame_raw);
+        }
+
+        if(enc->oc){
+            av_write_trailer(enc->oc);
+            if (enc->oc->pb){
+                avio_closep(&enc->oc->pb);
+            }
+            avformat_free_context(enc->oc);
+        }
+	free(enc);
+    }
+}

--- a/src/rviz_video_encoder/video_encoder.c
+++ b/src/rviz_video_encoder/video_encoder.c
@@ -46,8 +46,8 @@ VideoEncoder* video_encoder_init(VideoEncodeParams params){
     memset(enc,0,sizeof(VideoEncoder));
 
     enc->params = params;
-    if (enc->params.width % 2 || enc->params.height % 2){
-        fprintf(stderr,"%dx%d, dimensions not divisible by two!\n",enc->params.width,enc->params.height);
+    if (enc->params.width % 4 || enc->params.height % 4){
+        fprintf(stderr,"%dx%d, dimensions not divisible by four!\n",enc->params.width,enc->params.height);
         return NULL;
     }
     if (enc->params.width > enc->params.maxWidth) {
@@ -59,8 +59,8 @@ VideoEncoder* video_encoder_init(VideoEncodeParams params){
         enc->out_width = enc->params.width;
         enc->out_height = enc->params.height;
     }
-    enc->out_width -= enc->out_width % 2;
-    enc->out_height -= enc->out_height % 2;
+    enc->out_width -= enc->out_width % 4;
+    enc->out_height -= enc->out_height % 4;
 
     printf("[video encoder init] %d x %d --> %d x %d @ %f FPS\n",
 	   enc->params.width,enc->params.height,

--- a/src/rviz_video_encoder/video_encoder.h
+++ b/src/rviz_video_encoder/video_encoder.h
@@ -1,0 +1,42 @@
+#ifndef RVIZ_VIDEO_ENCODER_H
+#define RVIZ_VIDEO_ENCODER_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+struct _video_encoder;
+
+typedef struct _video_encoder VideoEncoder;
+
+typedef struct {
+    int width;
+    int height;
+    int fpsNum;
+    int fpsDen;
+    int maxWidth;
+    int keyed;
+
+    // constant rate factor metric
+    double crf;
+
+    // speed/quality tradeoff [slowest ... fastest]
+    const char* preset;
+
+    // AVPixelFormat enum. Is hardcoded (for now) to RGB32, as this will always be what Ogre gives us.
+    int inFmt;
+
+    // path to output file: ie: /a/b/c/captured.mp4
+    // will auto-detect container format based on file extension.
+    const char* output_path;
+} VideoEncodeParams;
+
+VideoEncoder* video_encoder_init(VideoEncodeParams args);
+int video_encoder_encode_frame(VideoEncoder *enc, const uint8_t *pixels);
+void video_encoder_destroy(VideoEncoder *enc);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* RVIZ_VIDEO_ENCODER_H */


### PR DESCRIPTION
If you're running this outside the docker container, you'll need to have [xxHash](https://github.com/Cyan4973/xxHash) installed on your system.

```
git clone https://github.com/Cyan4973/xxHash
cd xxHash
make
sudo make install
sudo ldconfig
```

`rviz` now will output `captured.mp4`, `captured_keyed.mp4` and `thumnail.jpg` - no post-processing required. 

Highlights:
  * encodes both mp4s on the fly. frame-buffer level control from ogre screenshot to the mp4 container! 
  * uses xxHash to detect unchanged frames (for keyed mp4)
  * creates a thumnail halfway through the bag (using QImage jpeg export).
