### PR TITLE
video_encoder: enable mp4 faststart, support mp4 streaming

### DIFF
--- a/src/rviz_video_encoder/video_encoder.c
+++ b/src/rviz_video_encoder/video_encoder.c
@@ -164,8 +164,15 @@ VideoEncoder* video_encoder_init(VideoEncodeParams params){
         return NULL;
     }
 
+    AVDictionary *mp4opt = NULL;
+    av_dict_copy(&mp4opt,NULL,0);
+
+    //faststart (enable second pass to put MOOV atom at beginning of file
+    //allow playback to start before file download is complete, streaming)
+    av_dict_set(&mp4opt, "movflags","faststart", 0);
+
     fprintf(stdout,"Writing header\n");
-    ret = avformat_write_header(enc->oc,NULL);
+    ret = avformat_write_header(enc->oc,&mp4opt);
     if (ret < 0){
         fprintf(stderr," error writing output file header: %s\n",av_err2str(ret));
         return NULL;


### PR DESCRIPTION
Video encoder will produce `mp4` files that video players can "stream" (play as the `mp4` file is downloading). As of now, players would have to receive the entire `mp4` file before starting playback.

This works by enabling a second pass when packaging the `mp4` transport stream, which moves all of the metadata about the video stream (the `MOOV atom`) from the end of the `mp4` file to the beginning. 

When the web play starts downloading the `mp4` file, it will now be able to start playing the video file as soon as the `MOOV` atom is decoded, rather than waiting for the entire `mp4` file to download. 

You can check if a particular mp4 is set up this way using the `mediainfo` command on linux:

```sh
$ mediainfo -f ~/Downloads/with-faststart.mp4 | grep IsStreamable
IsStreamable                             : Yes
$ mediainfo -f ~/Downloads/current.mp4 | grep IsStreamable
IsStreamable                             : No
```
More background here: https://rigor.com/blog/2016/01/optimizing-mp4-video-for-fast-streaming