### PR TITLE
logging: consolidate and clean-up

### DIFF
--- a/scripts/openbox
+++ b/scripts/openbox
@@ -1,8 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 echo "openbox: using config file: ${1}"
-cat "${1}"
 echo "openbox: will touch file '${2}' when ready"
 openbox_args="${3:-}"
-
+echo "openbox: using additional arguments ${openbox_args}"
 exec openbox ${openbox_args} --sm-disable --config-file "${1}" --startup "touch '${2}'"

--- a/scripts/openbox
+++ b/scripts/openbox
@@ -3,4 +3,6 @@ set -euo pipefail
 echo "openbox: using config file: ${1}"
 cat "${1}"
 echo "openbox: will touch file '${2}' when ready"
-exec openbox --sm-disable --debug --config-file "${1}" --startup "touch '${2}'"
+openbox_args="${3:-}"
+
+exec openbox ${openbox_args} --sm-disable --config-file "${1}" --startup "touch '${2}'"

--- a/src/rviz/visualization_manager.cpp
+++ b/src/rviz/visualization_manager.cpp
@@ -664,7 +664,7 @@ void VisualizationManager::onUpdate()
         std::array<char, 128> buffer;
         std::string result;
 
-        ROS_INFO("[vm/rvnsnap] running '%s'",command.c_str());
+        ROS_DEBUG("[vm/rvnsnap] running '%s'",command.c_str());
         FILE* pipe = popen(command.c_str(), "r");
         if (!pipe)
             {
@@ -675,9 +675,9 @@ void VisualizationManager::onUpdate()
             result += buffer.data();
         }
         int return_code = pclose(pipe);
-        ROS_INFO("[vm/rvnsnap] '%s' returns %d\n%s",command.c_str(),return_code,result.c_str());
+        ROS_DEBUG("[vm/rvnsnap] '%s' returns %d\n%s",command.c_str(),return_code,result.c_str());
         if(return_code != 0){
-            ROS_ERROR("[vm/rvnsnap] failed to successfully run rvnsnap");
+            ROS_ERROR("[vm/rvnsnap] failed to successfully run '%s' returns %d\n%s",command.c_str(),return_code,result.c_str());
             dbus_->call("kill");
             exit(EXIT_FAILURE);
         }


### PR DESCRIPTION
Also provide a means to supply extra flags to `openbox`. This is used to toggle `--debug` flag from the `batch-worker` go process.